### PR TITLE
Lininglouis

### DIFF
--- a/code/data_ml_functions/dataFunctions.py
+++ b/code/data_ml_functions/dataFunctions.py
@@ -31,6 +31,8 @@ from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 from tqdm import tqdm
 import warnings
+import cv2
+
 
 def prepare_data(params):
     """
@@ -123,8 +125,10 @@ def _process_file(file, slashes, root, isTrain, outDir, params):
         return noResult
 
     try:
-        img = image.load_img(os.path.join(root, imgFile))
-        img = image.img_to_array(img)
+#        img = image.load_img(os.path.join(root, imgFile))
+#        img = image.img_to_array(img)
+        img = cv2.imread(os.path.join(root, imgFile)).astype(np.float32)
+        img = img[:,:,::-1]
     except:
         return noResult
 
@@ -213,9 +217,11 @@ def _process_file(file, slashes, root, isTrain, outDir, params):
             continue
 
         subImg = img[r1:r2, c1:c2, :]
-        subImg = image.array_to_img(subImg)
-        subImg = subImg.resize(params['target_img_size'])
-        subImg.save(imgPath)
+#        subImg = image.array_to_img(subImg)
+#        subImg = subImg.resize(params['target_img_size'])
+#        subImg.save(imgPath)
+        subImg = cv2.resize(subImg, params['target_img_size']).astype(np.uint8)[:,:,::-1]
+        cv2.imwrite(imgPath, subImg)
 
         features = json_to_feature_vector(params, jsonData, bb)
         features = features.tolist()

--- a/code/data_ml_functions/dataFunctions.py
+++ b/code/data_ml_functions/dataFunctions.py
@@ -128,7 +128,7 @@ def _process_file(file, slashes, root, isTrain, outDir, params):
 #        img = image.load_img(os.path.join(root, imgFile))
 #        img = image.img_to_array(img)
         img = cv2.imread(os.path.join(root, imgFile)).astype(np.float32)
-        img = img[:,:,::-1]
+    
     except:
         return noResult
 
@@ -220,7 +220,7 @@ def _process_file(file, slashes, root, isTrain, outDir, params):
 #        subImg = image.array_to_img(subImg)
 #        subImg = subImg.resize(params['target_img_size'])
 #        subImg.save(imgPath)
-        subImg = cv2.resize(subImg, params['target_img_size']).astype(np.uint8)[:,:,::-1]
+        subImg = cv2.resize(subImg, params['target_img_size']).astype(np.uint8)
         cv2.imwrite(imgPath, subImg)
 
         features = json_to_feature_vector(params, jsonData, bb)


### PR DESCRIPTION
for loading large images, using PIL to do the image loading is very time-consuming. Opencv is much faster in this preparation step. For this sample image, shape (6000,9000,3) , cv2 takes only 50% of PIL processing time. It saves more memory than runing the prepare code with PIL(At least for my 16GB RAM machine).  
 
Below is a performance test
`
from keras.preprocessing import image
import numpy as np    
import timeit

def load_PIL():
    img_path = r'..\val\airport\airport_1\airport_1_3_rgb.jpg'
    img = image.load_img(img_path)
    img = image.img_to_array(img)
    subImg = image.array_to_img(img)
    #subImg = subImg.resize((224,224)  )  

def load_cv2():
    import cv2; 
    img_path = r'..\val\airport\airport_1\airport_1_3_rgb.jpg'
    img_cv2 = cv2.imread(img_path).astype(np.float32)
    img_cv2 = img_cv2[:,:,::-1]
    #img  = cv2.resize(img_cv2, (224, 224)) 


print ('PIL', timeit.timeit(load_PIL, number=10))
print ('cv2', timeit.timeit(load_cv2, number=10))
`